### PR TITLE
Enhance hole punching

### DIFF
--- a/cmd/pcp/pcp.go
+++ b/cmd/pcp/pcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dennis-tra/pcp/internal/log"
 	"github.com/dennis-tra/pcp/pkg/receive"
 	"github.com/dennis-tra/pcp/pkg/send"
+	logging "github.com/ipfs/go-log/v2"
 )
 
 var (
@@ -45,6 +46,7 @@ func main() {
 		Before: func(c *cli.Context) error {
 			if c.Bool("debug") {
 				log.SetLevel(log.DebugLevel)
+				logging.SetLogLevel("p2p-holepunch", "debug")
 			}
 			return nil
 		},


### PR DESCRIPTION
We can try to establish direct connection before transfer (while hole-punching is going on background). I also enable `libp2p` "p2p-holepunching" log when `-debug` flag set, so we can see why hole punching fail (in my case it will mostly timeout with the default dial timeout value). 